### PR TITLE
Attempt getting status code using native http request

### DIFF
--- a/lib/Arachnid.js
+++ b/lib/Arachnid.js
@@ -22,4 +22,7 @@ const Arachnid = async (domain) => {
 };
 
 
+Arachnid("https://bitsofco.de/styling-broken-images/")
+.then(res => console.log(res))
+
 module.exports = Arachnid;

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -1,3 +1,5 @@
+const request = require('./promiseRequest');
+
 const findImages = async (page) => await page.evaluate(() => Array.from(document.images, image => {
   return {
     imageAlternateText: image.alt,
@@ -5,7 +7,17 @@ const findImages = async (page) => await page.evaluate(() => Array.from(document
   }
 }));
 
-const addImageStatusCode = async (page, images) => {
+const addImageStatusCode = async (some, images) => {
+  return await Promise.all(images.map(async image => {
+    const response = await request(image.imageSource);
+    return {
+      ...image,
+      statusCode: response.statusCode,
+    }
+  }));
+}
+
+const addImageStatusCode2 = async (page, images) => {
   return await Promise.all(images.map(async image => {
     const response = await page.goto(image.imageSource, {waitUntil: 'domcontentloaded'});
     return {
@@ -13,6 +25,6 @@ const addImageStatusCode = async (page, images) => {
       statusCode: response.status(),
     }
   }));
-}
+};
 
 module.exports = { findImages, addImageStatusCode };

--- a/lib/mainExtractor.js
+++ b/lib/mainExtractor.js
@@ -54,7 +54,10 @@ const extractMeta = async (page) => {
 const extractImages = async (page) => {
     return new Promise(async (resolve, reject) => {
         try {
+            console.time();
             const imagesWithStatusCode = await addImageStatusCode(page, await findImages(page));
+            console.log('logging time addImageStatusCode using node native http request')
+            console.timeEnd();
             const imagesBroken = imagesWithStatusCode
                 .filter(image => image.statusCode > 399)
                 .map(image => image.imageSource);
@@ -63,7 +66,7 @@ const extractImages = async (page) => {
                 .map(image => image.imageSource);
             resolve({broken: imagesBroken, missingAlt: imagesWithoutAlt});
         } catch(ex) {
-            resolve({error: ex});
+            reject({error: ex});
         }
       });
 }  

--- a/lib/promiseRequest.js
+++ b/lib/promiseRequest.js
@@ -1,0 +1,19 @@
+const https = require('https');
+const http = require('http');
+
+const requestPromise = (url) => {
+    const request = url.startsWith('https') ? https : http;
+    return new Promise ((resolve, reject) => {
+        request.get(url, (response, error) => {
+            if (response.statusCode >= 301) {
+                //TODO: handle request redirect
+            }
+            if (error) {
+                reject(error);
+            }
+            resolve(response);
+        })
+    }); 
+}
+
+module.exports = requestPromise;


### PR DESCRIPTION
After trying simple performance comparison, seems like the puppeteer page call is the winner. 

Puppeteer with existing code takes ~160-180ms to run `addImageStatusCode` method  
<img width="442" alt="image" src="https://user-images.githubusercontent.com/24622190/91645440-bfd4d800-ea4d-11ea-8a9e-38a9a979c230.png">

while the proposed solution to use NodeJS native http request took around the double timing
<img width="473" alt="image" src="https://user-images.githubusercontent.com/24622190/91645467-09252780-ea4e-11ea-91c3-2874da92d407.png">
