### PR TITLE
Scrap infos from nestedLinks, 1 depth

### DIFF
--- a/lib/Arachnid.js
+++ b/lib/Arachnid.js
@@ -3,17 +3,38 @@
 const puppeteer = require('puppeteer');
 const mainExtractor = require('./mainExtractor');
 
-const Arachnid = async (domain) => {
-  const browser = await puppeteer.launch({ headless: true });
+const constructor = async (browser, domain, goNext) => {
   const page = await browser.newPage();
-  const response = await page.goto(domain, {waitUntil: 'domcontentloaded'});
-  const extractedInfo = await mainExtractor(page);
+  const response = await page.goto(domain, {waitUntil: 'domcontentloaded', timeout:0});
+  const extractedInfo = await mainExtractor(page, goNext);
+
+  return {
+    response,
+    extractedInfo
+  }
+}
+
+const Arachnid = async (domain) => {
+  const browser = await puppeteer.launch({headless: true});
+
+  const {response, extractedInfo} = await constructor(browser, domain, true);
+
+  const nestedLinks = await Promise.all(extractedInfo.links.map(async (link) => {
+    const {response, extractedInfo} = await constructor(browser, link, false)
+    return {
+      statusCode: response.status(),
+      statusText: response.statusText(),
+      contentType: response.headers()['content-type'],
+      ...extractedInfo,
+    }
+  }));
 
   const output = {
       statusCode: response.status(),
       statusText: response.statusText(),
       contentType: response.headers()['content-type'],
-      ...extractedInfo
+      ...extractedInfo,
+      nestedLinks
   };
 
   await browser.close();

--- a/lib/mainExtractor.js
+++ b/lib/mainExtractor.js
@@ -2,7 +2,7 @@
 
 const { findImages, addImageStatusCode } = require('./helper');
 
-const extractor = async (page) => {
+const extractor = async (page, goNext) => {
     const currentUrl = new URL(page.url());
     const extractPromises = [];
     extractPromises.push(page.title());
@@ -11,7 +11,9 @@ const extractor = async (page) => {
     extractPromises.push(extractMeta(page));
     extractPromises.push(extractImages(page));
     extractPromises.push(extractCanonical(page));
-    extractPromises.push(extractLinks(page, currentUrl.toString()));
+    if (goNext) {
+        extractPromises.push(extractLinks(page, currentUrl.toString()));
+    }
   
     const mainInfo = await Promise.all(extractPromises);
     return {
@@ -32,7 +34,7 @@ const extractSelectorContents = async (page, selector) => {
         try {
             resolve(extractElemContents(page, selector)); 
         } catch (error) {
-            resolve({errorInfo: error.message});
+            reject({errorInfo: error.message});
         }
     }); 
 };


### PR DESCRIPTION
Reuse main Arachnid functionality
Ought to disable the maximum timeout of puppeteer. Did manual test with google search result page, Links array had 90 links, took around ~90seconds. 

