### PR TITLE
Add response time number to crawled internal page

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Map(3) {
         "broken": []
       }
     ],
+    "responseTime": 0.34,
     "DOMInfo": {
       "title": "Example Domain",
       "h1": [

--- a/src/types/arachnid.d.ts
+++ b/src/types/arachnid.d.ts
@@ -26,6 +26,7 @@ export interface ResultInfo {
   redirectUrl?: string;
   DOMInfo?: ExtractedDomInfo;
   resourceInfo?: PageResourceType[];
+  responseTime?: number;
 }
 
 export interface CrawlPageResult {
@@ -34,6 +35,7 @@ export interface CrawlPageResult {
   extractedInfo?: ExtractedDomInfo;
   resourceInfo?: PageResourceType[];
   depth: number;
+  responseTime?: number;
 }
 
 export interface MetaInfo {


### PR DESCRIPTION
sample page info with response time:
```
Map {
  'https://www.npmjs.com/' => { url: 'https://www.npmjs.com/',
    urlEncoded: 'https://www.npmjs.com/',
    isInternal: true,
    statusCode: 200,
    statusText: '',
    contentType: 'text/html',
    robotsHeader: undefined,
    depth: 1,
    resourceInfo: [ [Object], [Object], [Object], [Object] ],
    responseTime: 0.39,
    DOMInfo:
     { title: 'npm | build amazing things',
       h1: [Array],
       h2: [Array],
       meta: [],
       images: [Object],
       canonicalUrl: '',
       uniqueOutLinks: 17 },
    isIndexable: true,
    indexabilityStatus: '' } }
```