### PR TITLE
chore(dep): updating jsdoc version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1629,12 +1629,12 @@
       "dev": true
     },
     "catharsis": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.11.tgz",
-      "integrity": "sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+      "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.14"
+        "lodash": "^4.17.15"
       }
     },
     "chalk": {
@@ -3262,25 +3262,25 @@
       }
     },
     "jsdoc": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.6.tgz",
-      "integrity": "sha512-znR99e1BHeyEkSvgDDpX0sTiTu+8aQyDl9DawrkOGZTTW8hv0deIFXx87114zJ7gRaDZKVQD/4tr1ifmJp9xhQ==",
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.7.tgz",
+      "integrity": "sha512-sxKt7h0vzCd+3Y81Ey2qinupL6DpRSZJclS04ugHDNmRUXGzqicMJ6iwayhSA0S0DwwX30c5ozyUthr1QKF6uw==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.9.4",
         "bluebird": "^3.7.2",
-        "catharsis": "^0.8.11",
+        "catharsis": "^0.9.0",
         "escape-string-regexp": "^2.0.0",
         "js2xmlparser": "^4.0.1",
         "klaw": "^3.0.0",
         "markdown-it": "^10.0.0",
         "markdown-it-anchor": "^5.2.7",
-        "marked": "^0.8.2",
+        "marked": "^2.0.3",
         "mkdirp": "^1.0.4",
         "requizzle": "^0.2.3",
         "strip-json-comments": "^3.1.0",
         "taffydb": "2.6.2",
-        "underscore": "~1.10.2"
+        "underscore": "~1.13.1"
       }
     },
     "jsdoc-api": {
@@ -3507,9 +3507,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.7.tgz",
+      "integrity": "sha512-BJXxkuIfJchcXOJWTT2DOL+yFWifFv2yGYOUzvXg8Qz610QKw+sHCvTMYwA+qWGhlA2uivBezChZ/pBy1tWdkQ==",
       "dev": true
     },
     "mdurl": {
@@ -5041,9 +5041,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
-      "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@types/node": "^14.14.20",
     "@types/puppeteer": "^5.4.2",
-    "jsdoc": "^3.6.6",
+    "jsdoc": "^3.6.7",
     "jsdoc-to-markdown": "^6.0.1",
     "prettier": "^2.2.1",
     "ts-migrate": "^0.1.13",


### PR DESCRIPTION
As it contained outdated dependency of "underscore" library which should be updated to version 1.12.1+

This is to fix [this dependency security issue](https://github.com/web-extractors/arachnid-seo-js/security/dependabot/package-lock.json/underscore/open)